### PR TITLE
Multiple code improvements - squid:S1118, squid:CommentedOutCodeLine, squid:S1213

### DIFF
--- a/src/main/java/uk/co/techblue/alfresco/client/Service.java
+++ b/src/main/java/uk/co/techblue/alfresco/client/Service.java
@@ -61,6 +61,16 @@ public abstract class Service<RT extends Resource> {
         initializeProviderFactory();
     }
 
+    /**
+     * Instantiates a new service.
+     * 
+     * @param restBaseUri the rest base uri
+     */
+    public Service(final String restBaseUri) {
+        this.restBaseUri = restBaseUri;
+        this.resourceProxy = getResourceProxy(getResourceClass(), restBaseUri);
+    }
+
     private static void initializeProviderFactory() {
         try {
             final ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
@@ -77,16 +87,6 @@ public abstract class Service<RT extends Resource> {
         logger.info("Registering custom Provider with Resteasy:" + providerClass.getName() + " ...");
         providerFactory.registerProvider(providerClass);
         logger.info("Registered custom Provider with Resteasy:" + providerClass.getName());
-    }
-
-    /**
-     * Instantiates a new service.
-     * 
-     * @param restBaseUri the rest base uri
-     */
-    public Service(final String restBaseUri) {
-        this.restBaseUri = restBaseUri;
-        this.resourceProxy = getResourceProxy(getResourceClass(), restBaseUri);
     }
 
     /**
@@ -167,7 +167,6 @@ public abstract class Service<RT extends Resource> {
             Object errorResponse = null;
             Exception cause = null;
             try {
-                // String error = clientResponse.getEntity(String.class);
                 errorResponse = clientResponse.getEntity(ServiceResponse.class);
                 if (errorResponse == null) {
                     errorResponse = clientResponse.getEntity(String.class);

--- a/src/main/java/uk/co/techblue/alfresco/dto/content/SearchRequest.java
+++ b/src/main/java/uk/co/techblue/alfresco/dto/content/SearchRequest.java
@@ -75,9 +75,6 @@ public class SearchRequest extends BaseDto {
      * @param query the query
      */
     public SearchRequest(final String query) {
-        /*
-         * if (StringUtils.isBlank(query)) { throw new IllegalArgumentException("Query String cannot be blank."); }
-         */
         this.query = query;
     }
 

--- a/src/main/java/uk/co/techblue/alfresco/dto/util/AlfrescoDtoUtil.java
+++ b/src/main/java/uk/co/techblue/alfresco/dto/util/AlfrescoDtoUtil.java
@@ -30,6 +30,8 @@ public class AlfrescoDtoUtil {
     /** The Constant ISO8601_PATTERN. */
     private static final String ISO8601_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSz";
 
+    private AlfrescoDtoUtil() {}
+
     /**
      * Parses the ISO8601 date string.
      * 

--- a/src/main/java/uk/co/techblue/alfresco/resteasy/providers/DocumentContentProvider.java
+++ b/src/main/java/uk/co/techblue/alfresco/resteasy/providers/DocumentContentProvider.java
@@ -164,9 +164,6 @@ public class DocumentContentProvider implements MessageBodyReader<DocumentConten
      */
     private void setDocumentAttributes(final ContentDisposition contentDisposition,
         final DocumentContent DocumentContent) {
-        // DocumentContent.setDocumentId(contentDisposition
-        // .getParameter(PARAM_DOCUMENT_ID));
-        // DocumentContent.setName(contentDisposition.getParameter(PARAM_FILENAME));
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 50 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava