### PR TITLE
squid:S00119 - Type parameter names should comply with a naming convention

### DIFF
--- a/src/main/java/uk/co/techblue/alfresco/client/Service.java
+++ b/src/main/java/uk/co/techblue/alfresco/client/Service.java
@@ -40,9 +40,9 @@ import uk.co.techblue.alfresco.resteasy.providers.MultipartFormAnnotationWriter;
 /**
  * The Class Service.
  * 
- * @param <RT> the generic type
+ * @param <R> the generic type
  */
-public abstract class Service<RT extends Resource> {
+public abstract class Service<R extends Resource> {
 
     /** The logger. */
     private static final Logger logger = Logger.getLogger(Service.class);
@@ -51,7 +51,7 @@ public abstract class Service<RT extends Resource> {
     protected final String restBaseUri;
 
     /** The resource proxy. */
-    protected final RT resourceProxy;
+    protected final R resourceProxy;
     
     private static final int HTTP_SOCKET_TIMEOUT = 100 * 1000; // Read timeout set to 100 Seconds
     
@@ -94,7 +94,7 @@ public abstract class Service<RT extends Resource> {
      * 
      * @return the resource class
      */
-    protected abstract Class<RT> getResourceClass();
+    protected abstract Class<R> getResourceClass();
 
     /**
      * Gets the resource proxy.
@@ -132,15 +132,15 @@ public abstract class Service<RT extends Resource> {
      * Gets the entity from response.
      * 
      * @param <T> the Entity type
-     * @param <EX> the Exception type to throw if parsing fails
+     * @param <E> the Exception type to throw if parsing fails
      * @param clientResponse the client response
      * @param exceptionClazz the exception class to throw if parsing fails
      * @return the entity
-     * @throws EX a subclass of AlfrescoServiceException
+     * @throws E a subclass of AlfrescoServiceException
      */
-    protected <T, EX extends AlfrescoServiceException> T parseEntityFromResponse(
-        final ClientResponse<T> clientResponse, final Class<EX> exceptionClazz)
-        throws EX {
+    protected <T, E extends AlfrescoServiceException> T parseEntityFromResponse(
+        final ClientResponse<T> clientResponse, final Class<E> exceptionClazz)
+        throws E {
         T entity = null;
         try {
             validateResponseSuccess(clientResponse, exceptionClazz);
@@ -154,14 +154,14 @@ public abstract class Service<RT extends Resource> {
     /**
      * Validate response success.
      * 
-     * @param <EX> the generic type
+     * @param <E> the generic type
      * @param clientResponse the client response
      * @param exceptionClazz the exception clazz
-     * @throws EX the eX
+     * @throws E the e
      */
-    protected <EX extends AlfrescoServiceException> void validateResponseSuccess(
-        final ClientResponse<?> clientResponse, final Class<EX> exceptionClazz)
-        throws EX {
+    protected <E extends AlfrescoServiceException> void validateResponseSuccess(
+        final ClientResponse<?> clientResponse, final Class<E> exceptionClazz)
+        throws E {
         final Family statusFamily = getStatusFamily(clientResponse);
         if (statusFamily != Family.SUCCESSFUL) {
             Object errorResponse = null;
@@ -175,7 +175,7 @@ public abstract class Service<RT extends Resource> {
             } catch (final ClientResponseFailure clientResponseFailure) {
                 cause = clientResponseFailure;
             }
-            EX exception = null;
+            E exception = null;
             final String genericErrorMsg = "Error occurred while creating new instance of exception class of type "
                 + exceptionClazz.getCanonicalName()
                 + " to throw the following error:\n" + errorResponse;

--- a/src/main/java/uk/co/techblue/alfresco/service/AbstractService.java
+++ b/src/main/java/uk/co/techblue/alfresco/service/AbstractService.java
@@ -21,9 +21,9 @@ import uk.co.techblue.alfresco.client.Service;
 /**
  * The Class AbstractService.
  * 
- * @param <RT> the generic type
+ * @param <R> the generic type
  */
-public abstract class AbstractService<RT extends Resource> extends Service<RT> {
+public abstract class AbstractService<R extends Resource> extends Service<R> {
 
     /** The auth ticket. */
     protected final String authTicket;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S00119 - Type parameter names should comply with a naming convention.
This pull request removes 40 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00119
Please let me know if you have any questions.
George Kankava