### PR TITLE
Multiple code improvements - squid:S1948, squid:S00115, squid:S1854

### DIFF
--- a/src/main/java/uk/co/techblue/alfresco/client/Service.java
+++ b/src/main/java/uk/co/techblue/alfresco/client/Service.java
@@ -221,7 +221,7 @@ public abstract class Service<RT extends Resource> {
      * @return the status family
      */
     private Family getStatusFamily(final ClientResponse<?> clientResponse) {
-        Family statusFamily = null;
+        Family statusFamily;
         if (clientResponse.getResponseStatus() == null) {
             final int statusCode = clientResponse.getStatus();
             statusFamily = getStatusFamily(statusCode);

--- a/src/main/java/uk/co/techblue/alfresco/dto/common/GroupSorter.java
+++ b/src/main/java/uk/co/techblue/alfresco/dto/common/GroupSorter.java
@@ -21,11 +21,11 @@ package uk.co.techblue.alfresco.dto.common;
 public enum GroupSorter {
 	
 	/** The authority name. */
-	authorityName,
+	AUTHORITY_NAME,
 	
 	/** The short name. */
-	shortName,
+	SHORT_NAME,
 	
 	/** The display name. */
-	displayName
+	DISPLAY_NAME
 }

--- a/src/main/java/uk/co/techblue/alfresco/dto/common/UserRole.java
+++ b/src/main/java/uk/co/techblue/alfresco/dto/common/UserRole.java
@@ -21,17 +21,17 @@ package uk.co.techblue.alfresco.dto.common;
 public enum UserRole {
     
     /** The Owner. */
-    Owner, 
+    OWNER, 
  /** The Coordinator. */
- Coordinator, 
+ COORDINATOR, 
  /** The Collaborator. */
- Collaborator, 
+ COLLABORATOR, 
  /** The Contributor. */
- Contributor, 
+ CONTRIBUTOR, 
  /** The Editor. */
- Editor, 
+ EDITOR, 
  /** The Consumer. */
- Consumer, 
+ CONSUMER, 
  /** The All. */
- All
+ ALL
 }

--- a/src/main/java/uk/co/techblue/alfresco/dto/content/ContentUploadForm.java
+++ b/src/main/java/uk/co/techblue/alfresco/dto/content/ContentUploadForm.java
@@ -90,7 +90,7 @@ public class ContentUploadForm implements Serializable {
     /** The file data. */
     @FormParam("filedata")
     @PartType(MediaType.APPLICATION_OCTET_STREAM)
-    private FileDataSource fileData;
+    private transient FileDataSource fileData;
 
     /**
      * Gets the file name.

--- a/src/test/java/uk/co/techblue/alfresco/client/test/AlfrescoServiceTest.java
+++ b/src/test/java/uk/co/techblue/alfresco/client/test/AlfrescoServiceTest.java
@@ -189,7 +189,7 @@ public class AlfrescoServiceTest {
         final GroupService userService = new GroupService(BASE_URL, AUTH_TICKET);
         try {
             final AuthorityQuery authorityQuery = new AuthorityQuery();
-            authorityQuery.setSortBy(GroupSorter.authorityName);
+            authorityQuery.setSortBy(GroupSorter.AUTHORITY_NAME);
             System.out.println(userService.getParentAuthorities(
                 "EMAIL_CONTRIBUTORS", authorityQuery));
         } catch (final GroupException e) {
@@ -201,7 +201,7 @@ public class AlfrescoServiceTest {
         final GroupService userService = new GroupService(BASE_URL, AUTH_TICKET);
         try {
             final AuthorityQuery authorityQuery = new AuthorityQuery();
-            authorityQuery.setSortBy(GroupSorter.authorityName);
+            authorityQuery.setSortBy(GroupSorter.AUTHORITY_NAME);
             System.out.println(userService.getChildAuthorities(
                 "ALFRESCO_ADMINISTRATORS", authorityQuery));
         } catch (final GroupException e) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1948 - Fields in a "Serializable" class should either be transient or serializable.
squid:S00115 - Constant names should comply with a naming convention.
squid:S1854 - Dead stores should be removed.
This pull request removes 65 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1948
https://dev.eclipse.org/sonar/rules/show/squid:S00115
https://dev.eclipse.org/sonar/rules/show/squid:S1854
Please let me know if you have any questions.
George Kankava