### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/uk/co/techblue/alfresco/dto/util/AlfrescoDtoUtil.java
+++ b/src/main/java/uk/co/techblue/alfresco/dto/util/AlfrescoDtoUtil.java
@@ -30,6 +30,8 @@ public class AlfrescoDtoUtil {
     /** The Constant ISO8601_PATTERN. */
     private static final String ISO8601_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSz";
 
+    private AlfrescoDtoUtil() {}
+
     /**
      * Parses the ISO8601 date string.
      * 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava