### PR TITLE
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous

### DIFF
--- a/src/main/java/uk/co/techblue/alfresco/dto/util/AlfrescoDtoUtil.java
+++ b/src/main/java/uk/co/techblue/alfresco/dto/util/AlfrescoDtoUtil.java
@@ -93,8 +93,7 @@ public class AlfrescoDtoUtil {
      * @throws IllegalArgumentException the illegal argument exception
      * @throws IllegalAccessException the illegal access exception
      */
-    public static Object getClassFieldValue(final Object object, final String fieldName) throws IllegalArgumentException,
-        IllegalAccessException {
+    public static Object getClassFieldValue(final Object object, final String fieldName) throws IllegalAccessException {
         for (final Field classField : object.getClass().getDeclaredFields()) {
             if (classField.getName().equals(fieldName)) {
                 classField.setAccessible(true);

--- a/src/main/java/uk/co/techblue/alfresco/jackson/ISO8601DateDeserializer.java
+++ b/src/main/java/uk/co/techblue/alfresco/jackson/ISO8601DateDeserializer.java
@@ -39,8 +39,7 @@ public class ISO8601DateDeserializer extends JsonDeserializer<Date> {
      */
     @Override
     public Date deserialize(final JsonParser jsonparser,
-        final DeserializationContext deserializationcontext) throws IOException,
-        JsonProcessingException {
+        final DeserializationContext deserializationcontext) throws IOException {
         final Timestamp timestamp = jsonparser.readValueAs(Timestamp.class);
         if (timestamp == null || StringUtils.isBlank(timestamp.getIso8601())) {
             return null;

--- a/src/main/java/uk/co/techblue/alfresco/jackson/ISO8601DateSerializer.java
+++ b/src/main/java/uk/co/techblue/alfresco/jackson/ISO8601DateSerializer.java
@@ -38,8 +38,7 @@ public class ISO8601DateSerializer extends JsonSerializer<Date> {
      */
     @Override
     public void serialize(final Date value, final JsonGenerator jgen,
-        final SerializerProvider provider) throws IOException,
-        JsonProcessingException {
+        final SerializerProvider provider) throws IOException {
         try {
             final String dateString = AlfrescoDtoUtil.formatISO8601Date(value);
             jgen.writeString(dateString);

--- a/src/main/java/uk/co/techblue/alfresco/jackson/UnquoteCharacterEscapeDeserializer.java
+++ b/src/main/java/uk/co/techblue/alfresco/jackson/UnquoteCharacterEscapeDeserializer.java
@@ -38,7 +38,7 @@ public class UnquoteCharacterEscapeDeserializer extends JsonDeserializer<Map<Str
      * org.codehaus.jackson.map.DeserializationContext)
      */
     @Override
-    public Map<String, String> deserialize(final JsonParser jsonparser, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    public Map<String, String> deserialize(final JsonParser jsonparser, final DeserializationContext ctxt) throws IOException {
         return jsonparser.configure(Feature.ALLOW_UNQUOTED_CONTROL_CHARS, true).readValueAs(new TypeReference<Map<String, String>>() {
         });
     }

--- a/src/main/java/uk/co/techblue/alfresco/resteasy/providers/HtmlBodyReader.java
+++ b/src/main/java/uk/co/techblue/alfresco/resteasy/providers/HtmlBodyReader.java
@@ -55,7 +55,7 @@ public class HtmlBodyReader implements MessageBodyReader<String> {
     public String readFrom(final Class<String> type, final Type genericType,
         final Annotation[] annotations, final MediaType mediaType,
         final MultivaluedMap<String, String> httpHeaders, final InputStream entityStream)
-        throws IOException, WebApplicationException {
+        throws IOException {
         final String response = ProviderHelper.readString(entityStream, mediaType);
         return response;
     }

--- a/src/main/java/uk/co/techblue/alfresco/resteasy/providers/MultipartFormAnnotationWriter.java
+++ b/src/main/java/uk/co/techblue/alfresco/resteasy/providers/MultipartFormAnnotationWriter.java
@@ -73,7 +73,7 @@ public class MultipartFormAnnotationWriter extends AbstractMultipartFormDataWrit
      */
     @Override
     public void writeTo(final Object obj, final Class<?> type, final Type genericType, final Annotation[] annotations, final MediaType mediaType,
-        final MultivaluedMap<String, Object> httpHeaders, final OutputStream entityStream) throws IOException, WebApplicationException
+        final MultivaluedMap<String, Object> httpHeaders, final OutputStream entityStream) throws IOException
     {
         final MultipartFormDataOutput multipart = new MultipartFormDataOutput();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck
Please let me know if you have any questions.
George Kankava