### PR TITLE
squid:S00115 - Constant names should comply with a naming convention

### DIFF
--- a/src/main/java/uk/co/techblue/alfresco/dto/common/GroupSorter.java
+++ b/src/main/java/uk/co/techblue/alfresco/dto/common/GroupSorter.java
@@ -21,11 +21,11 @@ package uk.co.techblue.alfresco.dto.common;
 public enum GroupSorter {
 	
 	/** The authority name. */
-	authorityName,
+	AUTHORITY_NAME,
 	
 	/** The short name. */
-	shortName,
+	SHORT_NAME,
 	
 	/** The display name. */
-	displayName
+	DISPLAY_NAME
 }

--- a/src/main/java/uk/co/techblue/alfresco/dto/common/UserRole.java
+++ b/src/main/java/uk/co/techblue/alfresco/dto/common/UserRole.java
@@ -21,17 +21,17 @@ package uk.co.techblue.alfresco.dto.common;
 public enum UserRole {
     
     /** The Owner. */
-    Owner, 
- /** The Coordinator. */
- Coordinator, 
- /** The Collaborator. */
- Collaborator, 
- /** The Contributor. */
- Contributor, 
- /** The Editor. */
- Editor, 
- /** The Consumer. */
- Consumer, 
- /** The All. */
- All
+    OWNER,
+    /** The Coordinator. */
+    COORDINATOR,
+    /** The Collaborator. */
+    COLLABORATOR,
+    /** The Contributor. */
+    CONTRIBUTOR,
+    /** The Editor. */
+    EDITOR,
+    /** The Consumer. */
+    CONSUMER,
+    /** The All. */
+    ALL
 }

--- a/src/test/java/uk/co/techblue/alfresco/client/test/AlfrescoServiceTest.java
+++ b/src/test/java/uk/co/techblue/alfresco/client/test/AlfrescoServiceTest.java
@@ -189,7 +189,7 @@ public class AlfrescoServiceTest {
         final GroupService userService = new GroupService(BASE_URL, AUTH_TICKET);
         try {
             final AuthorityQuery authorityQuery = new AuthorityQuery();
-            authorityQuery.setSortBy(GroupSorter.authorityName);
+            authorityQuery.setSortBy(GroupSorter.AUTHORITY_NAME);
             System.out.println(userService.getParentAuthorities(
                 "EMAIL_CONTRIBUTORS", authorityQuery));
         } catch (final GroupException e) {
@@ -201,7 +201,7 @@ public class AlfrescoServiceTest {
         final GroupService userService = new GroupService(BASE_URL, AUTH_TICKET);
         try {
             final AuthorityQuery authorityQuery = new AuthorityQuery();
-            authorityQuery.setSortBy(GroupSorter.authorityName);
+            authorityQuery.setSortBy(GroupSorter.AUTHORITY_NAME);
             System.out.println(userService.getChildAuthorities(
                 "ALFRESCO_ADMINISTRATORS", authorityQuery));
         } catch (final GroupException e) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S00115 - Constant names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00115
Please let me know if you have any questions.
George Kankava